### PR TITLE
docs: list Brazilian Portuguese workshop in resources page

### DIFF
--- a/pages/resources.md
+++ b/pages/resources.md
@@ -15,6 +15,7 @@ Our materials are designed to be learned in one of our [Humble Data workshops](h
 - [Spanish](https://humbledata.org/online_workshop_spanish/lab/index.html)
 - [Italian](https://humbledata.org/online-workshop-italian-v2/lab/index.html)
 - [French](https://humbledata.org/online-workshop-fr/)
+- [Brazilian Portuguese](https://humbledata.org/online_workshop_ptbr/lab/index.html)
 
 Please contact us if you'd like to help out the project by translating the materials into other languages!  
 


### PR DESCRIPTION
## Summary

Adds the Brazilian Portuguese edition of the workshop to the language list on the resources page, now that it's live at https://humbledata.org/online_workshop_ptbr/.

## Context

- Live site: https://humbledata.org/online_workshop_ptbr/
- Deploy repo: [HumbleData/online_workshop_ptbr](https://github.com/HumbleData/online_workshop_ptbr)
- Translation source: [PyLadiesSalvador/humbledata-iniciantes-ptbr](https://github.com/PyLadiesSalvador/humbledata-iniciantes-ptbr) (synced into the deploy repo via a sync script)

Related PR on the official workshop repo: HumbleData/beginners-data-workshop#108

## Test plan

- [ ] Verify the Brazilian Portuguese link resolves to the JupyterLite site
- [ ] Confirm the page renders correctly on the deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)